### PR TITLE
fix weird problem loading db in spring (rails)

### DIFF
--- a/lib/string_to_ipa/version.rb
+++ b/lib/string_to_ipa/version.rb
@@ -1,3 +1,3 @@
 module StringToIpa
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
This fixes a problem that prevented this this gem from being usable with [`spring`](https://github.com/rails/spring) (the part of `rails` that does "magical" preloading, which apparently breaks pretty easily).

Something to do with how `spring` interacts with constants, like `StringToIpa::DATABASE`.  I don't totally understand exactly what the problem was, but this fixes it by refactoring to a method that returns a database client, instead of loading it as a constant.

Shouldn't effect non-`spring` usage.
