### PR TITLE
Only open a database connection once per program

### DIFF
--- a/lib/string_to_ipa.rb
+++ b/lib/string_to_ipa.rb
@@ -68,7 +68,7 @@ module StringToIpa
     private
 
     def database
-      @database ||= begin
+      @@database ||= begin
         db = SQLite3::Database.new(File.join(File.expand_path(File.dirname(__FILE__)), "..", "ipagem.db"))
         db.results_as_hash = true
         db.execute( "PRAGMA encoding = \"UTF-16\"" )


### PR DESCRIPTION
Previously, the database connection was an instance variable
(`@database`), so every word was opening a separate connection to the
database. This was causing errors, where database connections would stay
open until a `StringToIpa` object gets GCed; errors were appearing where
a database would refuse new connections.

With this commit, the database connection is stored as a class variable,
and thus is only opened once per program.

This fixes issue #7 (https://github.com/hilarysk/string_to_ipa/issues/7).